### PR TITLE
feat: add backoff retry to docker version to avoid transient failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,3 +95,7 @@ linters-settings:
   gofumpt:
     extra-rules: true
     lang-version: "1.21"
+  ireturn:
+    allow:
+      - error
+      - backoff.BackOff

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/thegeeklab/wp-docker-buildx
 go 1.21
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/go-semver v0.3.1
 	github.com/rs/zerolog v1.30.0
 	github.com/thegeeklab/wp-plugin-go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=


### PR DESCRIPTION
Sometimes the docker daemon needs longer to start, resulting in issues similar to:

```
+ coredns -conf /etc/coredns/Corefile
+ /usr/local/bin/dockerd --data-root /var/lib/docker --host=unix:///var/run/docker.sock --dns 172.17.0.3
Detected registry credentials
+ /usr/local/bin/docker version
Client:
 Version:           20.10.21
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        baeda1f
 Built:             Tue Oct 25 17:56:30 2022
 OS/Arch:           linux/amd64
 Context:           default
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 Experimental:      true
time="2022-12-09T16:37:36Z" level=error msg="execution failed: exit status 1"
```

The backoff retry tries to mitigate such transient failures.