### PR TITLE
fix: add `--push` when only extra tags are used

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -108,7 +108,7 @@ func (b *Build) Run(env []string) *plugin_exec.Cmd {
 	maps.Copy(b.Args, defaultBuildArgs)
 
 	args = append(args, b.Context)
-	if !b.Dryrun && b.Output == "" && len(b.Tags) + len(b.ExtraTags) > 0 {
+	if !b.Dryrun && b.Output == "" && len(b.Tags)+len(b.ExtraTags) > 0 {
 		args = append(args, "--push")
 	}
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -108,7 +108,7 @@ func (b *Build) Run(env []string) *plugin_exec.Cmd {
 	maps.Copy(b.Args, defaultBuildArgs)
 
 	args = append(args, b.Context)
-	if !b.Dryrun && b.Output == "" && len(b.Tags) > 0 {
+	if !b.Dryrun && b.Output == "" && len(b.Tags) + len(b.ExtraTags) > 0 {
 		args = append(args, "--push")
 	}
 


### PR DESCRIPTION
I was using this plugin in a pipeline that I'm sharing across multiple repositories. I wanted to generate the registry URL before running the step that uses this plugin so that I could share it with other steps in the workflow, so I placed the tag into the `.extratags` file.

However, when the only tag(s) specified are extra tags (as opposed to the [`tags`](https://github.com/thegeeklab/wp-docker-buildx/blob/dc30cef2d744b39ececb4afd347adc41d9535f27/plugin/plugin.go#L202) parameter), the generated buildx command doesn't have the `--push` flag, even when `dry-run` is false. This PR fixes that issue.